### PR TITLE
docs: use raw OpenAPI URL with prism mock (no local YAML needed)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ $ pnpm link -—global dedalus-labs
 Most tests require you to [set up a mock server](https://github.com/stoplightio/prism) against the OpenAPI spec to run the tests.
 
 ```sh
-$ npx prism mock path/to/your/openapi.yml
+$ npx -y @stoplight/prism-cli mock https://raw.githubusercontent.com/dedalus-labs/dedalus-openapi/main/openapi.json
 ```
 
 ```sh

--- a/scripts/test
+++ b/scripts/test
@@ -43,7 +43,7 @@ elif ! prism_is_running ; then
   echo -e "To run the server, pass in the path or url of your OpenAPI"
   echo -e "spec to the prism command:"
   echo
-  echo -e "  \$ ${YELLOW}npm exec --package=@stainless-api/prism-cli@5.15.0 -- prism mock path/to/your.openapi.yml${NC}"
+  echo -e "  \$ ${YELLOW}npm exec --package=@stainless-api/prism-cli@5.15.0 -- npx -y @stoplight/prism-cli mock https://raw.githubusercontent.com/dedalus-labs/dedalus-openapi/main/openapi.json${NC}"
   echo
 
   exit 1


### PR DESCRIPTION
This updates the Prism quickstart to use the public OpenAPI JSON directly:

- Works without converting to YAML
- One-liner, copy/paste friendly
- Adds `-y` so npx runs non-interactively

Before:
```bash
npx prism mock path/to/your/openapi.yml
```

After:
```bash
npx -y @stoplight/prism-cli mock https://raw.githubusercontent.com/dedalus-labs/dedalus-openapi/main/openapi.json
```

Test:
```bash
curl http://127.0.0.1:4010/health
```

<img width="3100" height="1974" alt="image" src="https://github.com/user-attachments/assets/833c89b7-1cf3-4a61-9d7a-35e22e9eb418" />

Thanks for considering!