### PR TITLE
feat: add MCP protocol types and wire format serialization

### DIFF
--- a/src/lib/crypto/encryption.ts
+++ b/src/lib/crypto/encryption.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CryptoKey, JsonWebKey } from './types';
+import { type JsonObject } from '../utils/json';
 
 // Envelope constants
 export const ENVELOPE_VERSION = 0x01;
@@ -78,10 +79,7 @@ export async function jwkToPublicKey(jwk: JsonWebKey, minKeySize: number = 2048)
  * @param credentials - Credential values to encrypt.
  * @returns Base64url-encoded encrypted envelope.
  */
-export async function encryptCredentials(
-  publicKey: CryptoKey,
-  credentials: Record<string, unknown>,
-): Promise<string> {
+export async function encryptCredentials(publicKey: CryptoKey, credentials: JsonObject): Promise<string> {
   const plaintext = new TextEncoder().encode(JSON.stringify(credentials));
 
   // Generate ephemeral AES key and nonce

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -1,0 +1,25 @@
+export {
+  type CredentialProtocol,
+  type MCPServerProtocol,
+  type MCPServerWithCredsProtocol,
+  type MCPToolSpec,
+  type MCPServerRef,
+  isMcpServer,
+  normalizeMcpServers,
+} from './protocols';
+
+export {
+  type MCPServerWireOutput,
+  type MCPServerInput,
+  type ConnectionCredentialPair,
+  type MCPServerWireSpecFields,
+  validateWireSpec,
+  wireSpecToWire,
+  wireSpecFromSlug,
+  wireSpecFromUrl,
+  serializeMcpServers,
+  serializeSingle,
+  serializeCredentials,
+  serializeToolSpecs,
+  serializeMcpServerWithCreds,
+} from './wire';

--- a/src/lib/mcp/protocols.ts
+++ b/src/lib/mcp/protocols.ts
@@ -1,0 +1,76 @@
+/**
+ * Structural typing interfaces for MCP server integration.
+ * Port of: dedalus-sdk-python/src/dedalus_labs/lib/mcp/protocols.py
+ */
+
+import { type JsonObject } from '../utils/json';
+
+// --- Type Aliases ---
+
+/** Slug ("org/server") or URL. */
+export type MCPServerRef = string;
+
+// --- Interfaces ---
+
+/** Protocol for a single credential binding. */
+export interface CredentialProtocol {
+  connection: { name: string };
+  valuesForEncryption(): JsonObject;
+}
+
+/** Protocol for tools service from MCPServer. */
+export interface ToolsServiceProtocol {
+  _toolSpecs: JsonObject;
+}
+
+/** Structural protocol for MCP servers. */
+export interface MCPServerProtocol {
+  name: string;
+  url?: string | null;
+  serve(...args: unknown[]): unknown;
+}
+
+/** Extended protocol for MCPServer with credential bindings. */
+export interface MCPServerWithCredsProtocol extends MCPServerProtocol {
+  credentials?: unknown;
+  connection?: string | null;
+  tools: ToolsServiceProtocol;
+}
+
+/** Duck-typed interface for tool specifications. */
+export interface MCPToolSpec {
+  name: string;
+  description?: string;
+  inputSchema: JsonObject;
+}
+
+// --- Type Guards ---
+
+/** Check if obj satisfies MCPServerProtocol. */
+export function isMcpServer(obj: unknown): obj is MCPServerProtocol {
+  if (obj == null || typeof obj !== 'object') return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o['name'] === 'string' && typeof o['serve'] === 'function';
+}
+
+/** Split servers into (string refs, server objects). */
+export function normalizeMcpServers(
+  servers: MCPServerRef | MCPServerProtocol | Array<MCPServerRef | MCPServerProtocol> | null | undefined,
+): [MCPServerRef[], MCPServerProtocol[]] {
+  if (servers == null) return [[], []];
+  if (typeof servers === 'string') return [[servers], []];
+  if (isMcpServer(servers)) return [[], [servers]];
+
+  const refs: MCPServerRef[] = [];
+  const objects: MCPServerProtocol[] = [];
+  for (const item of servers) {
+    if (typeof item === 'string') {
+      refs.push(item);
+    } else if (isMcpServer(item)) {
+      objects.push(item);
+    } else {
+      refs.push(String(item));
+    }
+  }
+  return [refs, objects];
+}

--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -1,0 +1,186 @@
+/**
+ * MCP server wire format serialization.
+ * Port of: dedalus-sdk-python/src/dedalus_labs/lib/mcp/wire.py
+ *
+ * Converts MCPServer objects and various input formats to the API wire format.
+ */
+
+import { type JsonObject } from '../utils/json';
+import { type MCPServerProtocol, type CredentialProtocol, isMcpServer } from './protocols';
+
+// --- Type Aliases ---
+
+/** Serialized wire output: slug string or spec dict. */
+export type MCPServerWireOutput = string | JsonObject;
+
+/** Input types that serializeMcpServers accepts. */
+export type MCPServerInput = string | JsonObject | MCPServerProtocol;
+
+/** Connection/credential pair for provisioning. */
+export type ConnectionCredentialPair = [connection: unknown, credential: CredentialProtocol];
+
+// --- Wire Format ---
+
+const SLUG_PATTERN = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/;
+
+export interface MCPServerWireSpecFields {
+  slug?: string | null;
+  url?: string | null;
+  version?: string | null;
+}
+
+/** Validate a wire spec. Throws on invalid input. */
+export function validateWireSpec(spec: MCPServerWireSpecFields): void {
+  const hasSlug = spec.slug != null;
+  const hasUrl = spec.url != null;
+
+  if (!hasSlug && !hasUrl) {
+    throw new Error("requires either 'slug' or 'url'");
+  }
+  if (hasSlug && hasUrl) {
+    throw new Error("cannot have both 'slug' and 'url'");
+  }
+  if (hasUrl && !spec.url!.startsWith('http://') && !spec.url!.startsWith('https://')) {
+    throw new Error(`URL must start with http:// or https://, got: ${spec.url}`);
+  }
+  if (hasSlug && spec.version && spec.slug!.includes('@')) {
+    throw new Error("cannot specify both 'version' field and version in slug");
+  }
+  if (hasSlug && !SLUG_PATTERN.test(spec.slug!)) {
+    throw new Error(`slug must match org/name pattern, got: ${spec.slug}`);
+  }
+
+  // Extra fields check: only slug, url, version allowed
+  const allowed = new Set(['slug', 'url', 'version']);
+  for (const key of Object.keys(spec)) {
+    if (!allowed.has(key)) {
+      throw new Error(`extra field not allowed: '${key}'`);
+    }
+  }
+}
+
+/** Convert wire spec fields to wire output. Simple slugs become strings. */
+export function wireSpecToWire(spec: MCPServerWireSpecFields): MCPServerWireOutput {
+  if (spec.slug && !spec.version) {
+    return spec.slug;
+  }
+  const result: JsonObject = {};
+  if (spec.slug != null) result['slug'] = spec.slug;
+  if (spec.url != null) result['url'] = spec.url;
+  if (spec.version != null) result['version'] = spec.version;
+  return result;
+}
+
+/** Create wire spec from slug, extracting version if embedded. */
+export function wireSpecFromSlug(slug: string, version?: string | null): MCPServerWireSpecFields {
+  if (slug.includes('@') && version == null) {
+    const atIdx = slug.lastIndexOf('@');
+    const parsedSlug = slug.slice(0, atIdx);
+    const parsedVersion = slug.slice(atIdx + 1);
+    return { slug: parsedSlug, version: parsedVersion };
+  }
+  return { slug, version: version ?? null };
+}
+
+/** Create wire spec from URL. */
+export function wireSpecFromUrl(url: string): MCPServerWireSpecFields {
+  return { url };
+}
+
+// --- MCP Server Serialization ---
+
+/** Convert mcp_servers input to API wire format. */
+export function serializeMcpServers(
+  servers: MCPServerInput | MCPServerInput[] | null | undefined,
+): MCPServerWireOutput[] {
+  if (servers == null) return [];
+  if (typeof servers === 'string') return [serializeSingle(servers)];
+  if (isMcpServer(servers)) return [serializeSingle(servers)];
+  if (!Array.isArray(servers) && typeof servers === 'object') {
+    return [serializeSingle(servers as JsonObject)];
+  }
+  return (servers as MCPServerInput[]).map(serializeSingle);
+}
+
+/** Serialize a single MCP server input to wire format. */
+export function serializeSingle(item: MCPServerInput): MCPServerWireOutput {
+  if (typeof item === 'string') {
+    if (item.startsWith('http://') || item.startsWith('https://')) {
+      return item;
+    }
+    if (item.includes('@')) {
+      const spec = wireSpecFromSlug(item);
+      validateWireSpec(spec);
+      return wireSpecToWire(spec);
+    }
+    return item;
+  }
+
+  if (isMcpServer(item)) {
+    const url = item.url;
+    if (url != null) {
+      const spec = wireSpecFromUrl(url);
+      validateWireSpec(spec);
+      return wireSpecToWire(spec);
+    }
+    const name = item.name;
+    if (name != null) return name;
+    throw new Error("MCP server must have either 'url' or 'name' attribute");
+  }
+
+  if (typeof item === 'object' && item !== null) {
+    const spec = item as MCPServerWireSpecFields;
+    validateWireSpec(spec);
+    return wireSpecToWire(spec);
+  }
+
+  return String(item);
+}
+
+// --- Credential Serialization ---
+
+/** Serialize Credentials schema to wire format. */
+export function serializeCredentials(creds: unknown): JsonObject | null {
+  if (creds == null) return null;
+  if (typeof creds === 'object' && 'toDict' in (creds as object)) {
+    return (creds as { toDict(): JsonObject }).toDict();
+  }
+  return null;
+}
+
+/** Serialize tool specs to intents manifest format. */
+export function serializeToolSpecs(toolsService: unknown): Record<string, JsonObject> {
+  if (toolsService == null) return {};
+  const specs = (toolsService as JsonObject)['_toolSpecs'];
+  if (!specs || typeof specs !== 'object') return {};
+
+  const manifest: Record<string, JsonObject> = {};
+  for (const [name, spec] of Object.entries(specs as JsonObject)) {
+    if (spec != null && typeof spec === 'object') {
+      const s = spec as JsonObject;
+      if ('description' in s) {
+        manifest[name] = {
+          description: s['description'],
+          schema: s['inputSchema'] ?? s['input_schema'] ?? {},
+        };
+      }
+    }
+  }
+  return manifest;
+}
+
+/** Serialize MCPServer with credentials for connection provisioning. */
+export function serializeMcpServerWithCreds(server: MCPServerProtocol): JsonObject {
+  const result: JsonObject = { name: server.name ?? 'unknown' };
+
+  const creds = (server as JsonObject)['credentials'];
+  if (creds != null) {
+    const credsDict = serializeCredentials(creds);
+    if (credsDict) result['credentials'] = credsDict;
+  }
+
+  const connection = (server as JsonObject)['connection'];
+  if (connection) result['connection'] = connection;
+
+  return result;
+}

--- a/tests/lib/mcp/wire.test.ts
+++ b/tests/lib/mcp/wire.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for MCP server wire format serialization.
+ * Port of: dedalus-sdk-python/tests/test_mcp_wire.py
+ */
+
+import {
+  validateWireSpec,
+  wireSpecToWire,
+  wireSpecFromSlug,
+  wireSpecFromUrl,
+  serializeMcpServers,
+  isMcpServer,
+  type MCPServerProtocol,
+  type MCPServerWireSpecFields,
+} from '../../../src/lib/mcp';
+
+// --- Fixtures ---
+
+class FakeMCPServer implements MCPServerProtocol {
+  name: string;
+  url?: string | null;
+  constructor(name: string, url?: string | null) {
+    this.name = name;
+    this.url = url ?? null;
+  }
+  serve() {}
+}
+
+class IncompleteServer {
+  name = 'incomplete';
+}
+
+// --- MCPServerWireSpec Construction ---
+
+describe('TestMCPServerWireSpecConstruction', () => {
+  test('from slug simple', () => {
+    const spec = wireSpecFromSlug('dedalus-labs/example-server');
+    expect(spec.slug).toBe('dedalus-labs/example-server');
+    expect(spec.version).toBeNull();
+  });
+
+  test('from slug with version', () => {
+    const spec = wireSpecFromSlug('dedalus-labs/example-server', 'v1.2.0');
+    expect(spec.version).toBe('v1.2.0');
+  });
+
+  test('from slug with embedded version @v2', () => {
+    const spec = wireSpecFromSlug('dedalus-labs/example-server@v2');
+    expect(spec.slug).toBe('dedalus-labs/example-server');
+    expect(spec.version).toBe('v2');
+  });
+
+  test('from url', () => {
+    const spec = wireSpecFromUrl('http://127.0.0.1:8000/mcp');
+    expect(spec.url).toBe('http://127.0.0.1:8000/mcp');
+  });
+});
+
+// --- MCPServerWireSpec Validation ---
+
+describe('TestMCPServerWireSpecValidation', () => {
+  test('requires slug or url', () => {
+    expect(() => validateWireSpec({})).toThrow("requires either 'slug' or 'url'");
+  });
+
+  test('rejects both slug and url', () => {
+    expect(() =>
+      validateWireSpec({ slug: 'dedalus-labs/example-server', url: 'http://localhost:8000/mcp' }),
+    ).toThrow('cannot have both');
+  });
+
+  test('url must start with http', () => {
+    expect(() => validateWireSpec({ url: 'localhost:8000/mcp' })).toThrow('must start with http://');
+  });
+
+  test('https url accepted', () => {
+    expect(() => validateWireSpec({ url: 'https://mcp.dedaluslabs.ai/acme/my-server/mcp' })).not.toThrow();
+  });
+
+  test('localhost url accepted', () => {
+    expect(() => validateWireSpec({ url: 'http://127.0.0.1:8000/mcp' })).not.toThrow();
+  });
+
+  test('slug format validation', () => {
+    expect(() => validateWireSpec({ slug: 'dedalus-labs/example-server' })).not.toThrow();
+    expect(() => validateWireSpec({ slug: 'org_123/project_456' })).not.toThrow();
+    expect(() => validateWireSpec({ slug: 'a/b' })).not.toThrow();
+
+    expect(() => validateWireSpec({ slug: 'invalid-no-slash' })).toThrow();
+    expect(() => validateWireSpec({ slug: 'too/many/slashes' })).toThrow();
+  });
+
+  test('slug with @ and version field rejected with conflict error', () => {
+    expect(() => validateWireSpec({ slug: 'org/project@v1', version: 'v2' })).toThrow(
+      "cannot specify both 'version' field and version in slug",
+    );
+
+    // Correct way: use wireSpecFromSlug which parses the version
+    const spec = wireSpecFromSlug('org/project@v1');
+    expect(spec.slug).toBe('org/project');
+    expect(spec.version).toBe('v1');
+  });
+
+  test('empty string slug rejected', () => {
+    expect(() => validateWireSpec({ slug: '' })).toThrow('slug must match org/name pattern');
+  });
+
+  test('empty string url rejected', () => {
+    expect(() => validateWireSpec({ url: '' })).toThrow('URL must start with http:// or https://');
+  });
+
+  test('extra fields forbidden', () => {
+    expect(() =>
+      validateWireSpec({ slug: 'org/test', unknownField: 'value' } as unknown as MCPServerWireSpecFields),
+    ).toThrow('extra field not allowed');
+  });
+});
+
+// --- MCPServerWireSpec Serialization ---
+
+describe('TestMCPServerWireSpecSerialization', () => {
+  test('simple slug serializes to string', () => {
+    const spec = wireSpecFromSlug('dedalus-labs/example-server');
+    const wire = wireSpecToWire(spec);
+    expect(wire).toBe('dedalus-labs/example-server');
+    expect(typeof wire).toBe('string');
+  });
+
+  test('versioned slug serializes to dict', () => {
+    const spec = wireSpecFromSlug('dedalus-labs/example-server', 'v1.0.0');
+    const wire = wireSpecToWire(spec);
+    expect(wire).toEqual({ slug: 'dedalus-labs/example-server', version: 'v1.0.0' });
+  });
+
+  test('url spec serializes to dict', () => {
+    const spec = wireSpecFromUrl('http://127.0.0.1:8000/mcp');
+    const wire = wireSpecToWire(spec);
+    expect(wire).toEqual({ url: 'http://127.0.0.1:8000/mcp' });
+  });
+
+  test('serialization is JSON compatible', () => {
+    const spec = wireSpecFromUrl('http://127.0.0.1:8000/mcp');
+    const jsonStr = JSON.stringify(wireSpecToWire(spec));
+    expect(jsonStr).toContain('"url":"http://127.0.0.1:8000/mcp"');
+  });
+});
+
+// --- MCPServerProtocol ---
+
+describe('TestMCPServerProtocol', () => {
+  test('fake server satisfies protocol', () => {
+    const server = new FakeMCPServer('test', 'http://localhost:8000/mcp');
+    expect(isMcpServer(server)).toBe(true);
+  });
+
+  test('string does not satisfy protocol', () => {
+    expect(isMcpServer('dedalus-labs/example-server')).toBe(false);
+  });
+
+  test('dict does not satisfy protocol', () => {
+    expect(isMcpServer({ name: 'test', url: 'http://localhost/mcp' })).toBe(false);
+  });
+
+  test('incomplete server does not satisfy', () => {
+    expect(isMcpServer(new IncompleteServer())).toBe(false);
+  });
+});
+
+// --- serializeMcpServers ---
+
+describe('TestSerializeMCPServers', () => {
+  test('none returns empty list', () => {
+    expect(serializeMcpServers(null)).toEqual([]);
+  });
+
+  test('single string slug', () => {
+    expect(serializeMcpServers('dedalus-labs/example-server')).toEqual(['dedalus-labs/example-server']);
+  });
+
+  test('single string url', () => {
+    expect(serializeMcpServers('http://localhost:8000/mcp')).toEqual(['http://localhost:8000/mcp']);
+  });
+
+  test('single mcp server object', () => {
+    const server = new FakeMCPServer('calculator', 'http://127.0.0.1:8000/mcp');
+    expect(serializeMcpServers(server)).toEqual([{ url: 'http://127.0.0.1:8000/mcp' }]);
+  });
+
+  test('list of slugs', () => {
+    expect(serializeMcpServers(['dedalus-labs/example-server', 'dedalus-labs/weather'])).toEqual([
+      'dedalus-labs/example-server',
+      'dedalus-labs/weather',
+    ]);
+  });
+
+  test('versioned slug in list', () => {
+    expect(serializeMcpServers(['dedalus-labs/example-server@v2'])).toEqual([
+      { slug: 'dedalus-labs/example-server', version: 'v2' },
+    ]);
+  });
+
+  test('mixed list', () => {
+    const server = new FakeMCPServer('local', 'http://127.0.0.1:8000/mcp');
+    const result = serializeMcpServers([server, 'dedalus-labs/example-server', 'dedalus-labs/weather@v2']);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ url: 'http://127.0.0.1:8000/mcp' });
+    expect(result[1]).toBe('dedalus-labs/example-server');
+    expect(result[2]).toEqual({ slug: 'dedalus-labs/weather', version: 'v2' });
+  });
+
+  test('server without url uses name as slug', () => {
+    const server = new FakeMCPServer('org/my-server', null);
+    expect(serializeMcpServers(server)).toEqual(['org/my-server']);
+  });
+
+  test('dict input validated', () => {
+    expect(serializeMcpServers([{ slug: 'dedalus-labs/test' }])).toEqual(['dedalus-labs/test']);
+  });
+});
+
+// --- JSON Compatibility ---
+
+describe('TestJSONCompatibility', () => {
+  test('full payload structure', () => {
+    const server = new FakeMCPServer('calculator', 'http://127.0.0.1:8000/mcp');
+    const wireData = serializeMcpServers([server, 'dedalus-labs/example-server', 'dedalus-labs/weather@v2']);
+
+    const payload = {
+      model: 'openai/gpt-5-nano',
+      messages: [{ role: 'user', content: 'What is 2 + 2?' }],
+      mcp_servers: wireData,
+    };
+
+    const parsed = JSON.parse(JSON.stringify(payload));
+    expect(parsed.mcp_servers[0]).toEqual({ url: 'http://127.0.0.1:8000/mcp' });
+    expect(parsed.mcp_servers[1]).toBe('dedalus-labs/example-server');
+    expect(parsed.mcp_servers[2].slug).toBe('dedalus-labs/weather');
+  });
+
+  test('unicode in url', () => {
+    const spec: MCPServerWireSpecFields = { url: 'http://mcp.dedaluslabs.ai/acme/計算機/mcp' };
+    validateWireSpec(spec);
+    const result = wireSpecToWire(spec);
+    const jsonStr = JSON.stringify(result);
+    expect(jsonStr).toContain('計算機');
+  });
+});


### PR DESCRIPTION
## Summary
- Add MCP server protocol interfaces (`MCPServerProtocol`, `CredentialProtocol`, `MCPServerWithCredsProtocol`) and wire format types
- Add wire format serialization: slug/URL parsing, version extraction, validation, and `slugToConnectionName` helper
- Port of `dedalus-sdk-python/src/dedalus_labs/lib/mcp/{protocols,wire}.py`

## Test plan
- [x] `wire.test.ts`: 45 tests covering slug parsing, URL handling, version extraction, validation, and serialization