### PR TITLE
feat: add MCP request preparation with per-server credential scoping

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,8 @@ import { getPlatformHeaders } from './internal/detect-platform';
 import * as Shims from './internal/shims';
 import * as Opts from './internal/request-options';
 import { stringifyQuery } from './internal/utils/query';
+import { prepareMcpRequest } from './lib/mcp';
+import type { JsonObject } from './lib/utils/json';
 import { VERSION } from './version';
 import * as Errors from './core/error';
 import * as Uploads from './core/uploads';
@@ -398,6 +400,14 @@ export class Dedalus {
    * We preserve the structured output schemas, which are already in the correct format.
    */
   protected async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    // Encrypt MCP credentials before any other transforms
+    if (options.body && typeof options.body === 'object' && !Array.isArray(options.body)) {
+      const body = options.body as JsonObject;
+      if (body['credentials'] && body['mcp_servers']) {
+        options.body = await prepareMcpRequest(body, this.asBaseURL, this.fetch);
+      }
+    }
+
     if (options.body) {
       options.body = transformRequestBody(options.body);
     }

--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -17,6 +17,7 @@ export {
   wireSpecToWire,
   wireSpecFromSlug,
   wireSpecFromUrl,
+  slugToConnectionName,
   serializeMcpServers,
   serializeSingle,
   serializeCredentials,
@@ -28,3 +29,10 @@ export {
   validateCredentialsForServers,
   buildConnectionRecord,
 } from './wire';
+
+export {
+  type EncryptedCredentials,
+  prepareMcpRequest,
+  encryptCredentialsList,
+  embedCredentials,
+} from './request';

--- a/src/lib/mcp/request.ts
+++ b/src/lib/mcp/request.ts
@@ -1,0 +1,146 @@
+/**
+ * MCP request preparation.
+ * Port of: dedalus-sdk-python/src/dedalus_labs/lib/mcp/request.py
+ *
+ * Handles client-side preparation of MCP requests:
+ * 1. Serializes MCPServer objects to wire format
+ * 2. Deep copies to protect retry logic from mutation
+ * 3. Encrypts credentials client-side before transmission
+ */
+
+import { type JsonObject } from '../utils/json';
+import { encryptCredentials, fetchEncryptionKey } from '../crypto/encryption';
+import { type CredentialProtocol } from './protocols';
+import { serializeMcpServers, slugToConnectionName, type MCPServerWireOutput } from './wire';
+
+/** Map of connection names to encrypted envelopes (base64url). */
+export interface EncryptedCredentials {
+  [connectionName: string]: string;
+}
+
+// --- Request Preparation ---
+
+/**
+ * Serialize mcp_servers, deep copy, and encrypt credentials.
+ *
+ * @param data - Request body dict.
+ * @param asUrl - Authorization server URL for fetching encryption key.
+ * @param fetchFn - Optional fetch implementation (defaults to global fetch).
+ * @returns A new dict with serialized servers and encrypted credentials.
+ */
+export async function prepareMcpRequest(
+  data: JsonObject,
+  asUrl?: string | null,
+  fetchFn?: typeof fetch,
+): Promise<JsonObject> {
+  // Serialize MCP servers, if provided.
+  const servers = data['mcp_servers'];
+  if (servers != null) {
+    data['mcp_servers'] = serializeMcpServers(servers as Parameters<typeof serializeMcpServers>[0]);
+  }
+
+  // Read credentials from original data BEFORE deep clone (functions survive)
+  const credentials = data['credentials'];
+
+  // If credentials are provided, encrypt them on the client side
+  if (credentials && servers && asUrl) {
+    const publicKey = await fetchEncryptionKey(asUrl, fetchFn);
+    const credList = Array.isArray(credentials) ? credentials : [credentials];
+    const encrypted = await encryptCredentialsList(credList, publicKey);
+
+    // Deep copy to avoid mutation side effects
+    const result = JSON.parse(JSON.stringify(data)) as JsonObject;
+
+    if (Object.keys(encrypted).length > 0) {
+      result['mcp_servers'] = embedCredentials(result['mcp_servers'] as MCPServerWireOutput[], encrypted);
+      delete result['credentials'];
+    }
+
+    return result;
+  }
+
+  // No encryption needed — just deep copy
+  return JSON.parse(JSON.stringify(data)) as JsonObject;
+}
+
+// --- Internal Helpers ---
+
+/**
+ * Encrypt each credential.
+ *
+ * Supports both CredentialProtocol objects (from dedalus_mcp) and
+ * plain {connection_name, values} dicts (API type format).
+ */
+export async function encryptCredentialsList(
+  credentials: unknown[],
+  publicKey: CryptoKey,
+): Promise<EncryptedCredentials> {
+  const encrypted: EncryptedCredentials = {};
+
+  for (const cred of credentials) {
+    if (cred == null || typeof cred !== 'object') continue;
+    const c = cred as JsonObject;
+
+    // Extract connection name
+    let connectionName: string | null = null;
+    if (c['connection'] != null && typeof c['connection'] === 'object') {
+      connectionName = (c['connection'] as JsonObject)['name'] as string | null;
+    } else if (typeof c['connection_name'] === 'string') {
+      connectionName = c['connection_name'];
+    }
+
+    // Extract values
+    let values: JsonObject | null = null;
+    if (typeof c['valuesForEncryption'] === 'function') {
+      values = (c as CredentialProtocol).valuesForEncryption();
+    } else if (c['values'] != null && typeof c['values'] === 'object') {
+      values = c['values'] as JsonObject;
+    }
+
+    if (connectionName && values) {
+      encrypted[connectionName] = await encryptCredentials(publicKey, values);
+    }
+  }
+
+  return encrypted;
+}
+
+/**
+ * Return the subset of encrypted credentials that belongs to a server, or null.
+ *
+ * Derives the connection name via slugToConnectionName and looks it up in the
+ * full encrypted map.
+ */
+function credentialsForServer(
+  name: string,
+  allCreds: EncryptedCredentials,
+): { [conn: string]: string } | null {
+  const conn = slugToConnectionName(name);
+  const blob = allCreds[conn];
+  return blob ? { [conn]: blob } : null;
+}
+
+/**
+ * Embed encrypted credentials into each server spec.
+ *
+ * Each server receives only its own credentials, matched by connection name
+ * via slugToConnectionName.
+ */
+export function embedCredentials(
+  servers: MCPServerWireOutput[],
+  encrypted: EncryptedCredentials,
+): JsonObject[] {
+  return servers.map((server) => {
+    if (typeof server === 'string') {
+      const creds = credentialsForServer(server, encrypted);
+      if (server.startsWith('http://') || server.startsWith('https://')) {
+        return { url: server, name: server, credentials: creds };
+      }
+      return { slug: server, name: server, credentials: creds };
+    }
+    // Existing spec dict → derive name and scope credentials
+    const name = (server['name'] ?? server['slug'] ?? server['url'] ?? '') as string;
+    const creds = credentialsForServer(name, encrypted);
+    return { ...server, name, credentials: creds };
+  });
+}

--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -21,6 +21,11 @@ export type ConnectionCredentialPair = [connection: unknown, credential: Credent
 
 // --- Wire Format ---
 
+/** Derive canonical connection name from a server slug (org/server → org-server). */
+export function slugToConnectionName(slug: string): string {
+  return slug.replace(/\//g, '-');
+}
+
 const SLUG_PATTERN = /^[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+$/;
 
 export interface MCPServerWireSpecFields {

--- a/tests/lib/mcp/request.test.ts
+++ b/tests/lib/mcp/request.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for MCP request preparation orchestrator.
+ * Tests prepareMcpRequest, encryptCredentialsList, embedCredentials.
+ */
+
+import { prepareMcpRequest, embedCredentials, slugToConnectionName } from '../../../src/lib/mcp';
+import { b64urlDecode, NONCE_LEN } from '../../../src/lib/crypto/encryption';
+
+const RSA_ALGORITHM = { name: 'RSA-OAEP', hash: 'SHA-256' } as const;
+
+let privateKey: CryptoKey;
+let publicKey: CryptoKey;
+let jwk: JsonWebKey;
+
+// Mock fetch that returns JWKS
+function createMockFetch(jwkKey: JsonWebKey): typeof fetch {
+  return (async (_url: string | URL | Request) => {
+    return new Response(JSON.stringify({ keys: [{ ...jwkKey, use: 'enc', kid: 'test-1' }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+async function decryptEnvelope(
+  privKey: CryptoKey,
+  b64: string,
+  keySize: number,
+): Promise<Record<string, unknown>> {
+  const envelope = b64urlDecode(b64);
+  const keySizeBytes = keySize / 8;
+  const wrappedKey = envelope.slice(1, 1 + keySizeBytes);
+  const nonce = envelope.slice(1 + keySizeBytes, 1 + keySizeBytes + NONCE_LEN);
+  const ct = envelope.slice(1 + keySizeBytes + NONCE_LEN);
+  const aesKeyRaw = await crypto.subtle.decrypt(RSA_ALGORITHM, privKey, wrappedKey);
+  const aesKey = await crypto.subtle.importKey('raw', aesKeyRaw, { name: 'AES-GCM' }, false, ['decrypt']);
+  const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, aesKey, ct);
+  return JSON.parse(new TextDecoder().decode(pt));
+}
+
+beforeAll(async () => {
+  const kp = await crypto.subtle.generateKey(
+    { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true,
+    ['encrypt', 'decrypt'],
+  );
+  privateKey = kp.privateKey;
+  publicKey = kp.publicKey;
+  jwk = await crypto.subtle.exportKey('jwk', publicKey);
+});
+
+// --- TestPrepareMcpRequest ---
+
+describe('TestPrepareMcpRequest', () => {
+  test('full orchestration: encrypt, embed, strip plaintext', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      model: 'openai/gpt-4o-mini',
+      mcp_servers: ['org/server'],
+      credentials: [
+        { connection: { name: 'org-server' }, valuesForEncryption: () => ({ token: 'ghp_xxx' }) },
+      ],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    // credentials field removed
+    expect(result['credentials']).toBeUndefined();
+    // mcp_servers converted to spec dicts with scoped credentials
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!['slug']).toBe('org/server');
+    expect(servers[0]!['credentials']).toBeDefined();
+
+    // Verify per-server scoping: only org-server credential present
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    expect(Object.keys(creds)).toEqual(['org-server']);
+    const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
+    expect(decrypted).toEqual({ token: 'ghp_xxx' });
+  });
+
+  test('single credential object normalized to array', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: { connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'sk_xxx' }) },
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    expect(result['credentials']).toBeUndefined();
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    expect(creds['org-server']).toBeDefined();
+  });
+
+  test('multi-server: each server gets only its own credential', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['acme/github', 'acme/slack'],
+      credentials: [
+        { connection: { name: 'acme-github' }, valuesForEncryption: () => ({ token: 'ghp_xxx' }) },
+        {
+          connection: { name: 'acme-slack' },
+          valuesForEncryption: () => ({ webhook: 'https://hooks.slack.com/xxx' }),
+        },
+      ],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    expect(servers).toHaveLength(2);
+
+    // First server gets only github credential
+    const ghCreds = servers[0]!['credentials'] as Record<string, string>;
+    expect(Object.keys(ghCreds)).toEqual(['acme-github']);
+    const gh = await decryptEnvelope(privateKey, ghCreds['acme-github']!, 2048);
+    expect(gh).toEqual({ token: 'ghp_xxx' });
+
+    // Second server gets only slack credential
+    const slCreds = servers[1]!['credentials'] as Record<string, string>;
+    expect(Object.keys(slCreds)).toEqual(['acme-slack']);
+    const sl = await decryptEnvelope(privateKey, slCreds['acme-slack']!, 2048);
+    expect(sl).toEqual({ webhook: 'https://hooks.slack.com/xxx' });
+  });
+
+  test('plain Credential dicts work', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'org-server', values: { key: 'sk_test' } }],
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    const servers = result['mcp_servers'] as Record<string, unknown>[];
+    const creds = servers[0]!['credentials'] as Record<string, string>;
+    const decrypted = await decryptEnvelope(privateKey, creds['org-server']!, 2048);
+    expect(decrypted).toEqual({ key: 'sk_test' });
+  });
+
+  test('no credentials → passthrough', async () => {
+    const data = { model: 'openai/gpt-4o-mini', mcp_servers: ['org/server'] };
+    const result = await prepareMcpRequest(data, 'https://as.example.com');
+
+    expect(result['mcp_servers']).toEqual(['org/server']);
+  });
+
+  test('no mcp_servers → passthrough', async () => {
+    const data = {
+      model: 'openai/gpt-4o-mini',
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+    const result = await prepareMcpRequest(data, 'https://as.example.com');
+
+    expect(result['credentials']).toBeDefined(); // Not stripped since no servers
+  });
+
+  test('no asUrl → passthrough', async () => {
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+    const result = await prepareMcpRequest(data, null);
+
+    expect(result['credentials']).toBeDefined();
+  });
+
+  test('deep clone protects original data', async () => {
+    const mockFetch = createMockFetch(jwk);
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection: { name: 'org-server' }, valuesForEncryption: () => ({ key: 'secret' }) }],
+      extra: { nested: 'value' },
+    };
+
+    const result = await prepareMcpRequest(data, 'https://as.example.com', mockFetch);
+
+    // Result is a separate object
+    expect(result).not.toBe(data);
+    // Mutation of result doesn't affect original nested objects
+    (result['extra'] as Record<string, unknown>)['nested'] = 'mutated';
+    expect((data['extra'] as Record<string, unknown>)['nested']).toBe('value');
+  });
+
+  test('JWKS fetch error propagates', async () => {
+    const failFetch = (async () => new Response('', { status: 500 })) as typeof fetch;
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+
+    await expect(prepareMcpRequest(data, 'https://as.example.com', failFetch)).rejects.toThrow(
+      'failed to fetch JWKS',
+    );
+  });
+
+  test('no suitable RSA enc key throws', async () => {
+    const noKeyFetch = (async () =>
+      new Response(JSON.stringify({ keys: [{ kty: 'EC', use: 'sig' }] }), {
+        status: 200,
+      })) as typeof fetch;
+    const data: Record<string, unknown> = {
+      mcp_servers: ['org/server'],
+      credentials: [{ connection_name: 'api', values: { key: 'x' } }],
+    };
+
+    await expect(prepareMcpRequest(data, 'https://as.example.com', noKeyFetch)).rejects.toThrow(
+      'no RSA encryption key found',
+    );
+  });
+});
+
+// --- TestSlugToConnectionName ---
+
+describe('TestSlugToConnectionName', () => {
+  test('replaces slash with dash', () => {
+    expect(slugToConnectionName('org/server')).toBe('org-server');
+  });
+
+  test('no slash passes through', () => {
+    expect(slugToConnectionName('plain-name')).toBe('plain-name');
+  });
+
+  test('URL passes through with slash replaced', () => {
+    expect(slugToConnectionName('https://example.com/mcp')).toBe('https:--example.com-mcp');
+  });
+});
+
+// --- TestEmbedCredentials ---
+
+describe('TestEmbedCredentials', () => {
+  // Connection names use slugToConnectionName: org/server → org-server
+  const encrypted = { 'org-server': 'encrypted_blob_1', 'acme-slack': 'encrypted_blob_2' };
+
+  test('slug string gets only its own credential', () => {
+    const result = embedCredentials(['org/server'], encrypted);
+    expect(result[0]).toEqual({
+      slug: 'org/server',
+      name: 'org/server',
+      credentials: { 'org-server': 'encrypted_blob_1' },
+    });
+  });
+
+  test('multi-server: each gets only its own credential', () => {
+    const result = embedCredentials(['org/server', 'acme/slack'], encrypted);
+    expect(result[0]!['credentials']).toEqual({ 'org-server': 'encrypted_blob_1' });
+    expect(result[1]!['credentials']).toEqual({ 'acme-slack': 'encrypted_blob_2' });
+  });
+
+  test('unmatched server gets null credentials', () => {
+    const result = embedCredentials(['unknown/other'], encrypted);
+    expect(result[0]!['credentials']).toBeNull();
+  });
+
+  test('URL string gets scoped credentials', () => {
+    const urlCreds = { 'https:--mcp.example.com-server': 'blob_url' };
+    const result = embedCredentials(['https://mcp.example.com/server'], urlCreds);
+    expect(result[0]).toEqual({
+      url: 'https://mcp.example.com/server',
+      name: 'https://mcp.example.com/server',
+      credentials: { 'https:--mcp.example.com-server': 'blob_url' },
+    });
+  });
+
+  test('dict spec gets scoped credentials', () => {
+    const result = embedCredentials([{ slug: 'org/server', version: 'v2' }], encrypted);
+    expect(result[0]).toEqual({
+      slug: 'org/server',
+      version: 'v2',
+      name: 'org/server',
+      credentials: { 'org-server': 'encrypted_blob_1' },
+    });
+  });
+
+  test('name derived from slug/url/name field', () => {
+    const r1 = embedCredentials([{ slug: 'org/server' }], encrypted);
+    expect(r1[0]!['name']).toBe('org/server');
+
+    const r2 = embedCredentials([{ url: 'https://x.com/mcp' }], encrypted);
+    expect(r2[0]!['name']).toBe('https://x.com/mcp');
+
+    const r3 = embedCredentials([{ slug: 'org/server', name: 'custom' }], encrypted);
+    expect(r3[0]!['name']).toBe('custom');
+  });
+
+  test('dict with custom name uses name for credential lookup', () => {
+    const creds = { custom: 'blob_custom' };
+    const result = embedCredentials([{ slug: 'org/server', name: 'custom' }], creds);
+    expect(result[0]!['credentials']).toEqual({ custom: 'blob_custom' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `prepareMcpRequest` orchestrator: serializes MCP servers, encrypts credentials client-side, and embeds per-server scoped credential blobs
- Each server receives only its own encrypted credential (fixes credential-broadcast bug from Python SDK)
- Integrates MCP request preparation into `client.ts`
- Port of `dedalus-sdk-python/src/dedalus_labs/lib/mcp/request.py`

## Test plan
- [x] `request.test.ts`: 13 tests covering full orchestration, per-server scoping, passthrough cases, and error propagation