### PR TITLE
fix: use MCPServerWithCredsProtocol for type-safe credential access

### DIFF
--- a/src/lib/mcp/wire.ts
+++ b/src/lib/mcp/wire.ts
@@ -6,7 +6,12 @@
  */
 
 import { type JsonObject } from '../utils/json';
-import { type MCPServerProtocol, type CredentialProtocol, isMcpServer } from './protocols';
+import {
+  type MCPServerProtocol,
+  type MCPServerWithCredsProtocol,
+  type CredentialProtocol,
+  isMcpServer,
+} from './protocols';
 
 // --- Type Aliases ---
 
@@ -170,16 +175,16 @@ export function serializeToolSpecs(toolsService: unknown): Record<string, JsonOb
 }
 
 /** Serialize MCPServer with credentials for connection provisioning. */
-export function serializeMcpServerWithCreds(server: MCPServerProtocol): JsonObject {
+export function serializeMcpServerWithCreds(server: MCPServerWithCredsProtocol): JsonObject {
   const result: JsonObject = { name: server.name ?? 'unknown' };
 
-  const creds = (server as JsonObject)['credentials'];
+  const creds = server.credentials;
   if (creds != null) {
     const credsDict = serializeCredentials(creds);
     if (credsDict) result['credentials'] = credsDict;
   }
 
-  const connection = (server as JsonObject)['connection'];
+  const connection = server.connection;
   if (connection) result['connection'] = connection;
 
   return result;


### PR DESCRIPTION
## Summary
- Replace unsafe `as JsonObject` casts with proper typed property access in `serializeMcpServerWithCreds`
- Change parameter type from `MCPServerProtocol` to `MCPServerWithCredsProtocol`, which already declares `credentials` and `connection` fields

## Test plan
- [x] Lint clean
- [x] 46/46 MCP + crypto tests pass
- [x] `tsc --noEmit` zero errors
- [x] Full build succeeds
- [x] All 7 SDK example scripts verified working